### PR TITLE
GitHub Workflows Debug Upload Coverage Report

### DIFF
--- a/.github/workflows/ci_run.yml
+++ b/.github/workflows/ci_run.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.12', '3.13.0-rc.1' ]
+        python-version: [ '3.10', '3.12', '3.13.0-rc.2' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -31,6 +31,7 @@ jobs:
 
       - name: Upload Test Coverage Reports
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: treescriptify-text-${{ matrix.python-version }}-cov
           path: htmlcov/


### PR DESCRIPTION
- Ensure that Coverage Report is always uploaded, specifically when coverage fails
- Try upgrading Python 3.13 to rc2